### PR TITLE
bugfix: replace hardcoded iface with variable

### DIFF
--- a/src/mesh11sd
+++ b/src/mesh11sd
@@ -2275,7 +2275,7 @@ elif [ "$1" = "status" ]; then
 				peernum=0
 				peers=$(iw dev $iface mpath dump 2>/dev/null | grep -c -w $iface)
 				macrouting=$(iw dev $iface mpath dump 2>/dev/null | awk -F" " 'NR>1 {printf "%s/%s/%s/%s/%s ",$1,$2,$5,$11,$12}')
-				peer_macs="$devicemac ""$(iw dev m-11s-0 mpath dump 2>/dev/null | awk -F" " 'NR>1 {printf "%s ",$1}')"
+				peer_macs="$devicemac ""$(iw dev $iface mpath dump 2>/dev/null | awk -F" " 'NR>1 {printf "%s ",$1}')"
 
 				echo "      \"this_node\":\"$devicemac\","
 				echo "      \"active_peers\":\"$peers\","


### PR DESCRIPTION
peer_macs is using a hardcoded interface name of `m-11s-0` when that may not always be the case. Use $iface variable.