### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ uci commit mesh11sd
 rootpassword="myrootpassword"
 /bin/passwd root << EOF
 $rootpassword
-$root password
+$rootpassword
 EOF
 ```
 


### PR DESCRIPTION
Typo in (second, CPE mode) script 'rootpassword' instead of 'root password'
