### PR TITLE
Fix octet calculations when converting from/to la

### DIFF
--- a/src/mesh11sd
+++ b/src/mesh11sd
@@ -1890,6 +1890,11 @@ convert_to_la() {
 		octet="$p1"
 	fi
 
+	local len=${#octet}
+	if [ "$len" -eq 1 ]; then
+		octet="0$octet"
+	fi
+
 	mac_la="$octet:$p2:$p3:$p4:$p5:$p6"
 }
 
@@ -1904,6 +1909,11 @@ convert_from_la() {
 		octet=$(printf '%x\n' "$(( 0x2 ^ 0x$p1 ))")
 	else
 		octet="$p1"
+	fi
+
+	local len=${#octet}
+	if [ "$len" -eq 1 ]; then
+		octet="0$octet"
 	fi
 
 	mac_from_la="$octet:$p2:$p3:$p4:$p5:$p6"


### PR DESCRIPTION
My router's MAC addres starts with a 0.

mesh11sd could NOT set up the gateway interface due to an error in calculating it's mac address.

There was an error from hostapd in the logfile, showing a too-short BSSID.
The BSSID had only one digit in the first section.

I used the similar code that already existed in the `make_indexed_mac` function.
