### PR TITLE
Fix - `auto_config disable` does not delete `auto_config_test` file

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,5 @@
 mesh11sd (7.0.0)
+  * Fix - `auto_config disable` does not delete `auto_config_test` file [khoohaoyit]
   * Fix - shorten ssid suffix string [bluewavenet]
   * Fix - set default debuglevel to 3 [bluewavenet]
   * Fix - 5GHz scan channel fail on multi-band wiphys [bluewavenet]

--- a/src/mesh11sd
+++ b/src/mesh11sd
@@ -6454,7 +6454,7 @@ elif [ "$1" = "auto_config" ]; then
 		if [ "$reply" = "yes" ]; then
 
 			if [ -e "$tmpdir/auto_config_test" ]; then
-				rm "$tmpdir/auto_config_test 2> /dev/null"
+				rm "$tmpdir/auto_config_test" 2> /dev/null
 			fi
 
 			changes=$(uci changes mesh11sd)


### PR DESCRIPTION
Found a typo while looking at the source code

### Steps:
1. `mesh11sd auto_config enable`
2. `mesh11sd auto_config disable`

### Excepted behavior:
Should delete `auto_config_test` file

### Actual behavior:
Prints out `rm: can't remove '/tmp/mesh11sd/auto_config_test 2> /dev/null': No such file or directory`