### PR TITLE
Fix - do not wait for interfaces when printing version or help

### DIFF
--- a/src/mesh11sd
+++ b/src/mesh11sd
@@ -6915,7 +6915,11 @@ else
 	mesh11sdpid=$(pgrep -f "/bin/sh /usr/sbin/mesh11sd")
 fi
 
-get_current_setup 2> /dev/null
+# Skip the expensive runtime setup for informational options.
+case "$1" in
+	""|-h|--help|help|-v|--version|version) ;;
+	*) get_current_setup 2> /dev/null ;;
+esac
 
 if [ -z "$1" ] || [ "$1" = "-h" ] || [ $1 = "--help" ] || [ $1 = "help" ]; then
 	echo "


### PR DESCRIPTION
`get_current_setup()` runs before any argument is parsed, so `mesh11sd -v` and `mesh11sd -h` collect the whole runtime environment first. That includes `refresh_bridgemac()`, which calls `wait_for_interface()` for `br-lan`; when that interface is not up, the poll loop runs for the full `interface_timeout`, ten seconds by default.

On a running router `br-lan` is up, the loop exits on its first iteration and the delay is invisible. It shows up wherever the interface is absent or still coming up — such as the OpenWrt package CI container, which has no `br-lan` at all. That CI probes every installed executable for its version with a ten second timeout, so each probe was killed before mesh11sd printed anything.

A trace of `mesh11sd -v` there, 1147 steps totalling 10.41 s:

```
1.010s  + sleep 1     (×10)
0.027s  ++ pgrep -f '/bin/sh /usr/sbin/mesh11sd'
0.015s  ++ grep -c -w 'state UP'
```

The informational branches need only `$version` and `$tmpdir`, both set at the top of the script, so the setup pass can be skipped for them.

Verified against unpatched master, both run under the same shell, that every informational invocation keeps its exact output and exit status:

| argument | exit (master / patched) | stdout | master | patched |
|---|---|---|---|---|
| *(none)* | 0 / 0 | identical | 10.47 s | 0.06 s |
| `-h` | 0 / 0 | identical | 10.43 s | 0.06 s |
| `--help` | 0 / 0 | identical | 10.40 s | 0.05 s |
| `help` | 0 / 0 | identical | 10.49 s | 0.08 s |
| `-v` | 0 / 0 | identical | 10.43 s | 0.06 s |
| `--version` | 0 / 0 | identical | 10.47 s | 0.07 s |
| `version` | 0 / 0 | identical | 10.52 s | 0.06 s |

The case list matches exactly what the two branches below it already treat as help/version, so no other subcommand loses the setup pass.

Background in #203 — my first report there had the mechanism wrong and has been corrected.

Kept as a draft until the OpenWrt CI has run the same change as a package patch in openwrt/packages#30168; I will mark it ready once that confirms the version check passes.